### PR TITLE
fix: 404 missing to find proper CSS in subfolders

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -7,7 +7,7 @@ theme = "thingweb"
 
 # both following flags needed so that the content in /public uses correct locations
 uglyURLs = "true"
-relativeURLs = "true"
+#relativeURLs = "true" # https://github.com/eclipse-thingweb/website/issues/63
 
 #MetaDataFormat = "yaml"
 #DefaultContentLanguage = "en"


### PR DESCRIPTION
Hopefully fixes https://github.com/eclipse-thingweb/website/issues/63

Note1: I cannot check/test it locally on my Windows box since 404 pages do not work at all.
Note2: We should also check all other pages whether removing [relativeURLs](https://gohugo.io/content-management/urls/#relative-urls) option causes other issues...