### PR TITLE
Change name of thing

### DIFF
--- a/content/services.html
+++ b/content/services.html
@@ -102,7 +102,7 @@ menu: "main"
         </ul>
       </li>
       <li>
-        <b>Presence Sensor:</b> This is a simpler simulation of the coffee machine above. 
+        <b>Simple Coffee Machine:</b> This is a simpler simulation of the coffee machine above. 
         The interactions are possible via HTTP.
         TD:
         <ul>


### PR DESCRIPTION
It was a mistake, even the sentence reads as coffee machine