### PR TITLE
Update Eclipse links in footer

### DIFF
--- a/themes/thingweb/layouts/partials/footer.html
+++ b/themes/thingweb/layouts/partials/footer.html
@@ -32,15 +32,15 @@
             </div>
             <div class="copy text-center">
                 <p>
-                    <a href="http://www.eclipse.org">Eclipse</a>
+                    <a href="https://www.eclipse.org/">Eclipse</a>
                     <span>|</span>
-                    <a href="http://www.eclipse.org/legal/privacy.php">Privacy Policy</a>
+                    <a href="https://www.eclipse.org/legal/privacy/">Privacy Policy</a>
                     <span>|</span>
-                    <a href="http://www.eclipse.org/legal/termsofuse.php">Terms of Use</a>
+                    <a href="https://www.eclipse.org/legal/terms-of-use/">Terms of Use</a>
                     <span>|</span>
-                    <a href="http://www.eclipse.org/legal/copyright.php">Copyright Agent</a>
+                    <a href="https://www.eclipse.org/legal/copyright/">Copyright Agent</a>
                     <span>|</span>
-                    <a href="http://www.eclipse.org/legal">Legal</a>
+                    <a href="https://www.eclipse.org/legal/">Legal</a>
                     <span>|</span>
                     <a href="#" class="manage-cookies-link">Manage Consent</a>
                 </p>


### PR DESCRIPTION
Similar to https://github.com/eclipse-thingweb/playground/pull/594 we should update the Eclipse links...