### PR TITLE
Update docusaurus.config.js with more redirects

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -74,6 +74,14 @@ const config = {
       {
         redirects: [
           {
+            to: '/hands-on/articles',
+            from: '/hands-on',
+          },
+          {
+            to: '/hands-on/articles',
+            from: '/hands-on.html',
+          },
+          {
             to: '/hands-on/articles/intro-raspberry',
             from: '/hands-on-intro-raspberry',
           },

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -78,12 +78,28 @@ const config = {
             from: '/hands-on-intro-raspberry',
           },
           {
+            to: '/hands-on/articles/intro-raspberry',
+            from: '/hands-on-intro-raspberry.html',
+          },
+          {
             to: '/hands-on/articles/exposed-thing',
             from: '/hands-on-exposed-thing-guide',
           },
           {
+            to: '/hands-on/articles/exposed-thing',
+            from: '/hands-on-exposed-thing-guide.html',
+          },
+          {
             to: '/hands-on/articles/smart-coffee-machine',
             from: '/smart-coffee-machine',
+          },
+          {
+            to: '/hands-on/articles/smart-coffee-machine',
+            from: '/smart-coffee-machine.html',
+          },
+          {
+            to: '/services/',
+            from: '/services.html',
           },
         ],
       },


### PR DESCRIPTION
Note: I also added the version with `.html` since I think that was used before...

What is still missing

* get-involved.html (Question: where should it point to?)
* Examples pages (maybe they come later in some way)
  -  http://plugfest.thingweb.io/examples/smart-coffee-machine.html
  - http://plugfest.thingweb.io/examples/counter.html

see https://github.com/eclipse-thingweb/website/issues/94