### PR TITLE
Update Adopters numbers

### DIFF
--- a/src/components/CommunitySection/index.js
+++ b/src/components/CommunitySection/index.js
@@ -137,7 +137,7 @@ export default function CommunitySection() {
           </div>
 
           <div className={styles.stat}>
-            <h3 className={clsx(styles.stat__number, 'hero-title')} id='stats-number' data-val="5" data-count="true">0</h3>
+            <h3 className={clsx(styles.stat__number, 'hero-title')} id='stats-number' data-val="6" data-count="true">0</h3>
             <p className={styles.stat__description}>Adopters</p>
           </div>
         </div>


### PR DESCRIPTION
according to https://iot.eclipse.org/adopters/#iot.thingweb we now have 6

Note: Maybe it is possible to get this number automatically from the script that populates the logos ... 
Or we set a fixed number and once the script properly loads it updates this value.