### PR TITLE
Fixed configuration bug with the Algolia search

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -57,13 +57,6 @@ const config = {
         theme: {
           customCss: './src/css/custom.scss',
         },
-        // gtag: {
-        //   trackingID: 'G-FTBPVB8Z65',
-        //   anonymizeIP: true,
-        // },
-        // googleTagManager: {
-        //   containerId: 'G-FTBPVB8Z65',
-        // },
       }),
     ],
   ],
@@ -341,10 +334,10 @@ const config = {
         indexName: 'thingweb',
 
         // Optional: see doc section below
-        contextualSearch: true,
+        contextualSearch: false,
 
         // Optional: Algolia search parameters
-        // searchParameters: {},
+        searchParameters: {},
 
         // Optional: path for search page that enabled by default (`false` to disable it)
         searchPagePath: 'search',


### PR DESCRIPTION
I updated the Algolia Crawler configuration (Algolia dashboard) and set the `contextual` option to `false` in the Docusaurus config. With these changes, the search feature seems to be working properly now.

It looks like the contextual setting might have caused the crawler to look for results in other languages, which could explain why there weren't any results showing before.