### PR TITLE
Update some online things

### DIFF
--- a/services/introduction.md
+++ b/services/introduction.md
@@ -24,38 +24,4 @@ Using the tools below, you can interact with different WoT Things over your brow
 ## Online Things for Testing
 
 Eclipse Thingweb hosts Things that can be interacted with over the public Internet. You can use them to test your WoT applications.
-Note: we also offer the [test-things](https://github.com/eclipse-thingweb/test-things/) repository with a collection of IoT device simulators that can be used for testing and exploration purposes of different protocols and other Web of Things mechanisms.
-
-All of them require no security mechanism to be communicated with and have same behavior from CoAP or HTTP endpoints. Below are small explanations on what they can be used for:
-
-* Counter: It has a count property that can be read or observed and can be incremented or decremented via separate actions. It is also possible to reset the count value, obtain when the last change occurred, subscribe to a change in the count value or get the count value as an image. TDs:
-
-  * HTTP: [http://plugfest.thingweb.io:8083/counter](http://plugfest.thingweb.io:8083/counter)
-  * CoAP: coap://plugfest.thingweb.io:5683/counter
-
-* TestThing: This Thing exists primarily for testing different data schemas and payload formats. It also has events attached to affordances that notify when a value changes. TDs:
-
-  * HTTP: [http://plugfest.thingweb.io/http-data-schema-thing](http://plugfest.thingweb.io/http-data-schema-thing)
-  * CoAP: coap://plugfest.thingweb.io:5683/testthing
-
-* Smart Coffee Machine: This is a simulation of a coffee machine that also has a simple user interface that displays the values of properties. In addition to proving a real life device example, it can be used for testing uriVariables. You can ask it to brew different coffees and monitor the available resource level. TDs:
-
-  * HTTP: [http://plugfest.thingweb.io:8083/smart-coffee-machine](http://plugfest.thingweb.io:8083/smart-coffee-machine)
-  * CoAP: coap://plugfest.thingweb.io:5683/smart-coffee-machine
-
-* Presence Sensor: It mocks the detection of a person by firing an event every 5 seconds. Events are published via MQTT.
-
-  * TD: [https://zion.vaimee.com/things/urn:uuid:0a028f8e-8a91-4aaf-a346-9a48d440fd7c](https://zion.vaimee.com/things/urn:uuid:0a028f8e-8a91-4aaf-a346-9a48d440fd7c)
-
-* Smart Clock: It simply has a property affordance for the time. However, it runs 60 times faster than real-time to allow time-based decisions that can be easily tested. The interactions are possible via CoAP.
-
-  * TD: [https://zion.vaimee.com/things/urn:uuid:913cf8cb-3687-4d98-8d2f-f6f27cfc7162](https://zion.vaimee.com/things/urn:uuid:913cf8cb-3687-4d98-8d2f-f6f27cfc7162)
-
-* Simple Coffee Machine: This is a simpler simulation of the coffee machine above. The interactions are possible via HTTP.
-
-  * TD: [https://zion.vaimee.com/things/urn:uuid:7ba2bca0-a7f6-47b3-bdce-498caa33bbaf](https://zion.vaimee.com/things/urn:uuid:7ba2bca0-a7f6-47b3-bdce-498caa33bbaf)
-
-Additionally, Counter and Smart Coffee Machine offer simple UIs that reflect their state:
-
-* [Smart Coffee Machine](http://plugfest.thingweb.io/examples/smart-coffee-machine.html)
-* [Counter](http://plugfest.thingweb.io/examples/counter.html)
+You can find the details under the [test-things](https://github.com/eclipse-thingweb/test-things/) repository with a collection of IoT device simulators that can be used for testing and exploration purposes of different protocols and other Web of Things mechanisms.

--- a/services/introduction.md
+++ b/services/introduction.md
@@ -35,7 +35,7 @@ All of them require no security mechanism to be communicated with and have same 
 
 * TestThing: This Thing exists primarily for testing different data schemas and payload formats. It also has events attached to affordances that notify when a value changes. TDs:
 
-  * HTTP: [http://plugfest.thingweb.io:8083/testthing](http://plugfest.thingweb.io:8083/testthing)
+  * HTTP: [http://plugfest.thingweb.io/http-data-schema-thing](http://plugfest.thingweb.io/http-data-schema-thing)
   * CoAP: coap://plugfest.thingweb.io:5683/testthing
 
 * Smart Coffee Machine: This is a simulation of a coffee machine that also has a simple user interface that displays the values of properties. In addition to proving a real life device example, it can be used for testing uriVariables. You can ask it to brew different coffees and monitor the available resource level. TDs:


### PR DESCRIPTION
Based on https://github.com/eclipse-thingweb/test-things/pull/51/
we can update some online Things

I wonder
* what we shall do with the CoAP endpoints ?
* whether we shall update http://plugfest.thingweb.io:8083/smart-coffee-machine with http://plugfest.thingweb.io/http-advanced-coffee-machine

Yet another alternative is to stress the https://github.com/eclipse-thingweb/test-things/ repo and remove all links!?
