### PR TITLE
Make consent banner loading async

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -39,7 +39,7 @@ const config = {
     },
     {
       src: '/js/consentBanner.js',
-      async: false,
+      async: true,
     }
   ],
   presets: [


### PR DESCRIPTION
https://github.com/eclipse-thingweb/website/pull/93/files#diff-a038096cbdea434999e1dce5ab497212f1fe18204dde1a027ce3bdd663261a2aR42 was changing the consent banner loading but we are not sure. Doing a test deployment.